### PR TITLE
Small typo in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import gc
 import lvgl as lv
 
 from axpili9342 import ili9341
-from ft6x36c import ft6x36
+from ft6x36 import ft6x36
 
 display = ili9341()
 touch = ft6x36()


### PR DESCRIPTION
Fix typo in script (it is correct in `/examples`)